### PR TITLE
Fix error message on bad imported primitives return values

### DIFF
--- a/plai-lib/mutator.rkt
+++ b/plai-lib/mutator.rkt
@@ -378,8 +378,7 @@
                    [(void? result) (void)]
                    [(heap-value? result) (collector:alloc-flat result)]
                    [else 
-                    (error 'id (string-append "imported primitive must return <heap-value?>, "
-                                              "received ~a" result))]))))
+                    (error 'id "imported primitive must return <heap-value?>, received ~a" result)]))))
            ...))]
     [(_ maybe-id ...) 
      (ormap (λ (v) (and (not (identifier? v)) v)) (syntax->list #'(maybe-id ...)))

--- a/plai-lib/mutator.rkt
+++ b/plai-lib/mutator.rkt
@@ -378,7 +378,8 @@
                    [(void? result) (void)]
                    [(heap-value? result) (collector:alloc-flat result)]
                    [else 
-                    (error 'id "imported primitive must return <heap-value?>, received ~a" result)]))))
+                    (error 'id (string-append "imported primitive must return <heap-value?>, "
+                                              "received ~a") result)]))))
            ...))]
     [(_ maybe-id ...) 
      (ormap (λ (v) (and (not (identifier? v)) v)) (syntax->list #'(maybe-id ...)))


### PR DESCRIPTION
A mutator program that imports primitive that returns non-string values like this one leads to a cryptic error message:
```
#lang plai/gc2/mutator

(allocator-setup "mark-and-sweep.rkt" 100)
(import-primitives make-vector)
(define a (make-vector 3 3))
```

The error message that shows up is: 
```
string-append: contract violation
  expected: string?
  given: #(3 3 3)
  argument position: 3rd
  other arguments...:
```

This PR fixes bug in string-append part of the error message to prevent this from happening, which will change the error message to be more helpful:
```
make-vector: imported primitive must return <heap-value?>, received #(3 3 3)
```
