### PR TITLE
Allow multiple body expressions (or definitions) in type-case clauses.

### DIFF
--- a/plai-lib/tests/datatype.rkt
+++ b/plai-lib/tests/datatype.rkt
@@ -70,4 +70,7 @@
 
  (type-case "foo" "bar") =error> "this must be a type defined with define-type"
  (type-case + "bar") =error> "this must be a type defined with define-type"
- (type-case #f [x () 1]) =error> "this must be a type defined with define-type")
+ (type-case #f [x () 1]) =error> "this must be a type defined with define-type"
+
+ (type-case A (mta) [mta () (define x 2) x] [else (define x 3) x]) => 2
+ (type-case A (a (mtb)) [mta () (define x 2) x] [a (b) (define x 3) x]) => 3)


### PR DESCRIPTION
I understand the motivation for this restriction in the student languages, but PLAI provides `cond`, `case` and co from Racket, which all support multiple body expressions and definitions.

This PR brings `type-case` in line with the others.