### PR TITLE
Make test failures more readable, especially when getting exceptions.

### DIFF
--- a/plai-lib/test-harness.rkt
+++ b/plai-lib/test-harness.rkt
@@ -67,10 +67,17 @@
               #f)
           #t))
     (set! plai-all-test-results (cons result plai-all-test-results))
+    (define pf (if error? eprintf printf))
     (when print?
-      (if (abridged-test-output)
-          (apply (if error? eprintf printf) "(~s ~v ~v)\n" result)
-          (apply (if error? eprintf printf) "(~s ~s ~v ~v ~s)\n" result)))
+      (cond [(abridged-test-output)
+             (apply pf "(~s ~v ~v)\n" result)]
+            [else
+             (match-define `(,kind ,expr ,given ,expected ,line) result)
+             (if (eq? (first result) 'exception)
+                 (pf "~s ~s ~a\n  expected: ~a\n~a\n\n"
+                     kind expr line expected given)
+                 (pf "~s ~s ~a\n  expected: ~v\n  given: ~v\n\n"
+                     kind expr line expected given))]))
     (when (and halt-on-errors? error?)
       (raise (make-exn:test (string->immutable-string (format "test failed: ~s" result))
                             (current-continuation-marks))))))


### PR DESCRIPTION
Currently, the test messages are just lists, with Racket error messages inside strings (no linebreaks), which makes then very hard to read.

This PR does not yet update the PLAI test suite; I want to make sure people are interested in the change first.

Examples:
`(test (+ 3 'a) 4)`
```
exception (+ 3 'a) at line 3
  expected: <no-expected-value>
+: contract violation
  expected: number?
  given: 'a
  argument position: 2nd
  other arguments...:
   3
```

`(test 3 4)`
```
bad 3 at line 4
  expected: 4
  given: 3
```