### PR TITLE
Don't export `collect-garbage` from the collector language.

### DIFF
--- a/plai-lib/gc2/collector.rkt
+++ b/plai-lib/gc2/collector.rkt
@@ -6,7 +6,7 @@
          plai/gc2/private/gc-core
          syntax/parse/define)
 
-(provide (except-out (all-from-out scheme) #%module-begin error)
+(provide (except-out (all-from-out scheme) #%module-begin error collect-garbage)
          (all-from-out plai/gc2/private/gc-core)
          (all-from-out plai/datatype)
          (rename-out


### PR DESCRIPTION
Context: when I last taught PLAI, I had students submit collector modules sans actual collectors. Their allocator called their "non-existent" `collect-garbage` function, which happened to be Racket's (unrelated) `collect-garbage`. I think that should have been an error instead.