### PR TITLE
give better error message when type-case clause has no body

### DIFF
--- a/plai-lib/datatype.rkt
+++ b/plai-lib/datatype.rkt
@@ -370,6 +370,10 @@
 
 (define-for-syntax (validate-clause clause-stx)
   (syntax-case clause-stx ()
+    [(variant (field ...))
+     (plai-syntax-error
+      'type-case clause-stx
+      "this case is missing a body expression")]
     [(variant (field ...) body ...)
      (cond
        [(not (identifier? #'variant))
@@ -382,10 +386,6 @@
               'type-case malformed-field
               "this must be an identifier that names the value of a field"))]
        [else #t])]
-    [(variant (field ...))
-     (plai-syntax-error
-      'type-case clause-stx
-      "this case is missing a body expression")]
     [_
      (plai-syntax-error
       'type-case clause-stx
@@ -404,11 +404,14 @@
   (with-disappeared-uses
   (syntax-case stx (else)
     [(_ type-id test-expr [variant (field ...) case-expr ...] ... [else else-expr ...])
-     ;; Ensure that everything that should be an identifier is an identifier.
+     ;; Ensure that everything that should be an identifier is an identifier
+     ;; and all clauses have bodies.
      (and (identifier? #'type-id)
           (andmap identifier? (syntax->list #'(variant ...)))
           (andmap (λ (stx) (andmap identifier? (syntax->list stx)))
-                  (syntax->list #'((field ...) ...))))
+                  (syntax->list #'((field ...) ...)))
+          (andmap (lambda (stx) (pair? (syntax->list stx)))
+                  (syntax->list #'((case-expr ...) ...))))
      (let* ([info (validate-and-remove-type-symbol
                    #'type-id (syntax-local-value/record #'type-id plai-stx-type?))]
             [type-info (first info)]
@@ -445,11 +448,14 @@
                ...
                [else else-expr ...]))))]
     [(_ type-id test-expr [variant (field ...) case-expr ...] ...)
-     ;; Ensure that everything that should be an identifier is an identifier.
+     ;; Ensure that everything that should be an identifier is an identifier
+     ;; and all clauses have bodies.
      (and (identifier? #'type-id)
           (andmap identifier? (syntax->list #'(variant ...)))
           (andmap (λ (stx) (andmap identifier? (syntax->list stx)))
-                  (syntax->list #'((field ...) ...))))
+                  (syntax->list #'((field ...) ...)))
+          (andmap (lambda (stx) (pair? (syntax->list stx)))
+                  (syntax->list #'((case-expr ...) ...))))
      (let* ([info (validate-and-remove-type-symbol
                    #'type-id (syntax-local-value/record #'type-id plai-stx-type?))]
             [type-info (first info)]

--- a/plai-lib/tests/datatype.rkt
+++ b/plai-lib/tests/datatype.rkt
@@ -72,4 +72,5 @@
  (type-case #f [x () 1]) =error> "this must be a type defined with define-type"
 
  (type-case A (mta) [mta () (define x 2) x] [else (define x 3) x]) => 2
- (type-case A (a (mtb)) [mta () (define x 2) x] [a (b) (define x 3) x]) => 3)
+ (type-case A (a (mtb)) [mta () (define x 2) x] [a (b) (define x 3) x]) => 3
+ (type-case T 1 [i (f)]) =error> "type-case: this case is missing a body expression")


### PR DESCRIPTION
The old error was `let: bad syntax (missing binding pairs or body)`, and pointed to a src location in the implementation of `type-case`.