### PR TITLE
Proposal: Don't export set! from plai/gc2/collector.

### DIFF
--- a/plai-lib/gc2/collector.rkt
+++ b/plai-lib/gc2/collector.rkt
@@ -6,7 +6,7 @@
          plai/gc2/private/gc-core
          syntax/parse/define)
 
-(provide (except-out (all-from-out scheme) #%module-begin error collect-garbage)
+(provide (except-out (all-from-out scheme) #%module-begin error collect-garbage set!)
          (all-from-out plai/gc2/private/gc-core)
          (all-from-out plai/datatype)
          (rename-out


### PR DESCRIPTION
Context: we're using plai/gc2 for our PL course.
We have an assignment where students write their own GC, which must not do any PLAI-level allocation; all their state must be in the plai/gc2 heap.

One easy way to break that rule accidentally is to use PLAI-level mutable globals to hold GC state.
By not providing `set!` as part of the collector language, that's harder to do.

I don't know how others use plai/gc2, so maybe that change is not appropriate in other contexts, and/or would break collectors that are considered ok in other classes.
Just thought I'd throw the idea out there (@florence's ideal, really) to see what people think.

A bigger change that could also help with that would be to also remove `list`, `map`, etc. from the language, but I could see that breaking other ways of writing GCs that others may use.