### PR TITLE
Use font-size from preferences for heap visualizer.

### DIFF
--- a/plai-lib/gc2/private/gc-gui.rkt
+++ b/plai-lib/gc2/private/gc-gui.rkt
@@ -1,5 +1,6 @@
 #lang scheme/gui
 (require "gc-core.rkt")
+(require racket/draw)
 (provide heap-viz%)
 
 (define row-size 10)
@@ -30,7 +31,7 @@
              (= (vector-length pref) 2)
              (vector-ref pref 1))
         12))
-  (make-object font% size 'default))
+  (send the-font-list find-or-create-font size 'default 'normal 'normal))
 
 (define heap-canvas%
   (class* canvas% (heap-viz<%>)

--- a/plai-lib/gc2/private/gc-gui.rkt
+++ b/plai-lib/gc2/private/gc-gui.rkt
@@ -1,6 +1,6 @@
 #lang scheme/gui
 (require "gc-core.rkt")
-(require racket/draw)
+(require racket/draw framework)
 (provide heap-viz%)
 
 (define row-size 10)
@@ -19,18 +19,9 @@
 (define show-arrows? #t)
 (define show-highlighted-cells? #f)
 
-;; Should use preferences:get, but doesn't work here for some reason...
-;; Symptom: always gets the default value, doesn't read prefs file.
 ;; Future work: Support C-+ and C-- in the heap visualizer window.
 (define (get-proper-font)
-  (define pref
-    (get-preference
-     'plt:framework-pref:framework:standard-style-list:font-size))
-  (define size
-    (or (and (vector? pref)
-             (= (vector-length pref) 2)
-             (vector-ref pref 1))
-        12))
+  (define size (editor:get-current-preferred-font-size))
   (send the-font-list find-or-create-font size 'default 'normal 'normal))
 
 (define heap-canvas%

--- a/plai-lib/gc2/private/gc-gui.rkt
+++ b/plai-lib/gc2/private/gc-gui.rkt
@@ -18,6 +18,20 @@
 (define show-arrows? #t)
 (define show-highlighted-cells? #f)
 
+;; Should use preferences:get, but doesn't work here for some reason...
+;; Symptom: always gets the default value, doesn't read prefs file.
+;; Future work: Support C-+ and C-- in the heap visualizer window.
+(define (get-proper-font)
+  (define pref
+    (get-preference
+     'plt:framework-pref:framework:standard-style-list:font-size))
+  (define size
+    (or (and (vector? pref)
+             (= (vector-length pref) 2)
+             (vector-ref pref 1))
+        12))
+  (make-object font% size 'default))
+
 (define heap-canvas%
   (class* canvas% (heap-viz<%>)
     
@@ -129,7 +143,9 @@
                   (not (equal? h (send offscreen get-height))))
           (set! offscreen (make-object bitmap% w h)))
         (let ([dc (make-object bitmap-dc% offscreen)])
+          ;; this is a fresh dc, so need to re-setup properties
           (send dc set-smoothing 'aligned)
+          (send dc set-font (get-proper-font))
           (send dc clear)
           
           (send dc set-origin 0 0)
@@ -356,7 +372,8 @@
     (super-new)
     
     (setup-min-width/height)
-    (send (get-dc) set-smoothing 'aligned)))
+    (send (get-dc) set-smoothing 'aligned)
+    (send (get-dc) set-font (get-proper-font))))
 
 (define (round-up-to-even-multiple n cols)
   (let ([%% (remainder n cols)])


### PR DESCRIPTION
Default font size is unreadable in large lecture halls.

The way I'm reading preferences here is really sketchy, but I couldn't get `preferences:get` to work. It would always give me the default (which I had to set) and not look at my preferences file. I must be missing something obvious. @rfindler, any thoughts?